### PR TITLE
Fix timm dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ librosa
 albumentations
 albucore
 torchdiffeq
-timm
+timm>=1.0.9
 face_alignment
 av==12.0.0


### PR DESCRIPTION
0.6.13 doesn't provide timm.layers, which was deprecated long time ago 
Original code needs 1.0.9
Fixes #11 