### PR TITLE
Fix albumentations regretable behavior

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,6 +4,7 @@
 
 import os, torch, random, cv2, torchvision, subprocess, librosa, datetime, tempfile, face_alignment
 import numpy as np
+os.environ['NO_ALBUMENTATIONS_UPDATE'] = '1'  # Disable albumentations regretable behavior that checks internet
 import albumentations as A
 import albumentations.pytorch.transforms as A_pytorch
 


### PR DESCRIPTION
- By defaults it checks internet to see if a new version is available
- Removes confusing warning:
  UserWarning: A new version of Albumentations is available: 2.0.7
